### PR TITLE
Add Seedream AI Studio to AI image generation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@
 | Stableboost | 基于 Stable Diffusion 的图像生成与优化 | 基础免费 | 中 | 设计师、AI 爱好者 | [点击进入](https://stableboost.io/) |
 | GPT-IMAGE-1 | OpenAI 新一代图像生成模型，通过文本生成高质量图片 | 有限免费 | 低 | 普通用户、设计师 | [点击进入](https://openai.com/gpt-image-1) |
 | Kling | 高质量图像与视频生成，可灵 AI 驱动 | 每日免费点数 | 低 | 短视频创作者、设计师 | [点击进入](https://kling.kuaishou.com/) |
+| Seedream AI Studio | 多模型图像生成平台，集成 ByteDance Seedream 5.0/4.5/4.0，支持最多10张参考图风格融合，一键 Kling 2.1 图生视频 | 免费额度 | 低 | 设计师、创意工作者、内容创作者 | [点击进入](https://seedream4.video/) |
 
 
 ### **在线设计与图片编辑** 


### PR DESCRIPTION
## 新增内容 / What's being added

[Seedream AI Studio](https://seedream4.video/) — 多模型 AI 图像生成平台，集成 ByteDance Seedream 5.0/4.5/4.0，支持最多10张参考图风格融合，一键 Kling 2.1 图生视频。

## 为什么添加这个工具 / Why it belongs here

该列表已有 Kling、CapCut（含 Seedream 5.0）等相关工具，但缺少专门的 Seedream AI Studio：
- Seedream 5.0 最新在 AI 图像竞技场排名第一
- 支持多达10张参考图进行风格融合
- 含 Kling 2.1 一键图生视频功能  
- 有免费额度，适合设计师和内容创作者

## 添加位置 / Placement

添加在 **AI图像生成全能型** 分类的 Kling 条目之后，逻辑上紧密相关。