### PR TITLE
新增 NotFair（开源 Claude Code SEO 与广告技能集）到营销电商开源项目

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,6 +971,7 @@
 | AskMetric | AI驱动的电商数据采集与分析工具，支持指标可视化、关键词搜索和产品推荐 | 开源免费 | 中 | 开发者、电商分析师 | [点击进入](https://github.com/AskMetric) |
 | Automatic Product Trial | 自动商品试用系统，突破虚拟试衣局限，支持任意商品与人物照片智能合成 | 开源免费 | 中 | 开发者、服饰电商 | [点击进入](https://github.com/automatic-product-trial) |
 | Meridian | Google开源营销组合模型，提供Scenario Planner无代码工具测试预算和ROI预测 | 开源免费 | 中 | 营销分析师、数据团队 | [点击进入](https://github.com/google/meridian) |
+| NotFair | 开源 Claude Code 技能集，涵盖 SEO 分析、关键词研究、Google Ads 审计及 Meta Ads 优化；通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 接入实时数据 | 开源免费 | 中 | 开发者、SEO/广告运营团队 | [点击进入](https://github.com/nowork-studio/NotFair) |
 
 
 


### PR DESCRIPTION
感谢维护这份优质的 AI 工具合集！

这次 PR 在「营销电商类 → 开源项目」表格中新增 [NotFair](https://github.com/nowork-studio/NotFair)。

**NotFair 是什么？**

NotFair 是一套开源的 Claude Code 技能集（MIT 许可证，约 2.9k stars），专注于 SEO 与付费广告自动化：

- **SEO 模块**：站点分析、关键词研究、meta 标签优化、Schema 标记、GEO 优化、内容撰写
- **Google Ads 模块**：账户审计、搜索词清理、出价与预算建议
- **Meta Ads 模块**：ROAS 诊断、素材疲劳检测、受众重叠分析

通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 接入实时数据，让 AI Agent 直接操作广告账户（人工审批后执行）。

适合你们「开源项目」栏目中面向开发者和广告团队的工具。如需调整描述、格式或移至其他分类，请告知，随时配合修改。